### PR TITLE
[feature] #18 User 소속 Company Project 조회 기능 추가

### DIFF
--- a/module-api/src/main/java/com/welcommu/moduleapi/project/ProjectController.java
+++ b/module-api/src/main/java/com/welcommu/moduleapi/project/ProjectController.java
@@ -8,6 +8,7 @@ import com.welcommu.moduleservice.project.dto.ProjectAdminSummaryResponse;
 import com.welcommu.moduleservice.project.dto.ProjectCreateRequest;
 import com.welcommu.moduleservice.project.dto.ProjectDeleteRequest;
 import com.welcommu.moduleservice.project.dto.ProjectModifyRequest;
+import com.welcommu.moduleservice.project.dto.ProjectSummaryWithRoleDto;
 import com.welcommu.moduleservice.project.dto.ProjectUserResponse;
 import com.welcommu.moduleservice.project.dto.ProjectUserSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,10 +50,9 @@ public class ProjectController {
     }
 
     @GetMapping("/{projectId}")
-    @Operation(summary = "프로젝트 개별 조회")
-    public ResponseEntity<Optional<Project>> readProject(@PathVariable Long projectId
+    @Operation(summary = "프로젝트 개별 조회") public ResponseEntity<Optional<Project>> readProject(@PathVariable Long projectId, @AuthenticationPrincipal AuthUserDetailsImpl userDetails
     ) {
-        Optional<Project> project = projectService.getProject(projectId);
+        Optional<Project> project = projectService.getProject(userDetails.getUser(), projectId);
         return ResponseEntity.ok(project);
     }
 
@@ -99,5 +99,15 @@ public class ProjectController {
     public ResponseEntity<List<ProjectUserResponse>> readProjectUsers(@PathVariable Long projectId){
         List<ProjectUserResponse> projects = projectService.getUserListByProject(projectId);
         return ResponseEntity.ok(projects);
+    }
+
+    // ProjectController.java
+    @GetMapping("/company")
+    @Operation(summary = "내 회사 소속 프로젝트 전체 조회")
+    public ResponseEntity<List<ProjectSummaryWithRoleDto>> readAllMyCompanyProjects(
+        @AuthenticationPrincipal AuthUserDetailsImpl userDetails) {
+        Long companyId = userDetails.getUser().getCompany().getId();
+        return ResponseEntity.ok(projectService.getCompanyProjectsWithMyRole(companyId, userDetails.getUser()
+            .getId()));
     }
 }

--- a/module-api/src/main/java/com/welcommu/moduleapi/project/ProjectController.java
+++ b/module-api/src/main/java/com/welcommu/moduleapi/project/ProjectController.java
@@ -5,6 +5,7 @@ import com.welcommu.moduledomain.auth.AuthUserDetailsImpl;
 import com.welcommu.moduledomain.project.Project;
 import com.welcommu.moduleservice.project.ProjectService;
 import com.welcommu.moduleservice.project.dto.ProjectAdminSummaryResponse;
+import com.welcommu.moduleservice.project.dto.ProjectCompanyResponse;
 import com.welcommu.moduleservice.project.dto.ProjectCreateRequest;
 import com.welcommu.moduleservice.project.dto.ProjectDeleteRequest;
 import com.welcommu.moduleservice.project.dto.ProjectModifyRequest;
@@ -50,9 +51,9 @@ public class ProjectController {
     }
 
     @GetMapping("/{projectId}")
-    @Operation(summary = "프로젝트 개별 조회") public ResponseEntity<Optional<Project>> readProject(@PathVariable Long projectId, @AuthenticationPrincipal AuthUserDetailsImpl userDetails
+    @Operation(summary = "프로젝트 개별 조회") public ResponseEntity<Project> readProject(@PathVariable Long projectId, @AuthenticationPrincipal AuthUserDetailsImpl userDetails
     ) {
-        Optional<Project> project = projectService.getProject(userDetails.getUser(), projectId);
+        Project project = projectService.getProject(userDetails.getUser(), projectId);
         return ResponseEntity.ok(project);
     }
 
@@ -109,5 +110,14 @@ public class ProjectController {
         Long companyId = userDetails.getUser().getCompany().getId();
         return ResponseEntity.ok(projectService.getCompanyProjectsWithMyRole(companyId, userDetails.getUser()
             .getId()));
+    }
+
+    @GetMapping("/{projectId}/companies")
+    @Operation(summary = "프로젝트 소속 회사 목록 조회")
+    public ResponseEntity<List<ProjectCompanyResponse>> getProjectCompanies(
+        @PathVariable Long projectId
+    ) {
+        List<ProjectCompanyResponse> responses = projectService.getCompaniesByProjectId(projectId);
+        return ResponseEntity.ok(responses);
     }
 }

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -22,10 +22,6 @@ spring:
       hibernate:
         format_sql: true
 
-  properties:
-    hibernate:
-      format_sql: true
-
 logging:
   level:
     org.springframework.security: DEBUG

--- a/module-domain/src/main/java/com/welcommu/moduledomain/ProjectCompany/ProjectCompany.java
+++ b/module-domain/src/main/java/com/welcommu/moduledomain/ProjectCompany/ProjectCompany.java
@@ -1,0 +1,49 @@
+package com.welcommu.moduledomain.ProjectCompany;
+
+import com.welcommu.moduledomain.company.Company;
+import com.welcommu.moduledomain.project.Project;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "project_company")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProjectCompany {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setProject(Project project) {
+        this.project = project;
+    }
+
+    public void setCompany(Company company) {
+        this.company = company;
+    }
+}

--- a/module-repository/src/main/java/com/welcommu/modulerepository/project/ProjectCompanyRepository.java
+++ b/module-repository/src/main/java/com/welcommu/modulerepository/project/ProjectCompanyRepository.java
@@ -1,0 +1,12 @@
+package com.welcommu.modulerepository.project;
+
+import com.welcommu.moduledomain.ProjectCompany.ProjectCompany;
+import com.welcommu.moduledomain.project.Project;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectCompanyRepository extends JpaRepository<ProjectCompany, Long> {
+    void deleteByProject(Project project);
+    List<ProjectCompany> findByProjectId(Long projectId);
+
+}

--- a/module-repository/src/main/java/com/welcommu/modulerepository/project/ProjectRepository.java
+++ b/module-repository/src/main/java/com/welcommu/modulerepository/project/ProjectRepository.java
@@ -7,9 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface ProjectRepository extends JpaRepository<Project, Long> {
+public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectRepositoryCustom {
 
     Project findByIdAndIsDeletedFalse(Long projectId);
-
-    Optional<Project> findById(Long projectId);
 }

--- a/module-repository/src/main/java/com/welcommu/modulerepository/project/ProjectRepositoryCustom.java
+++ b/module-repository/src/main/java/com/welcommu/modulerepository/project/ProjectRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.welcommu.modulerepository.project;
+
+import com.welcommu.moduledomain.project.Project;
+import java.util.List;
+
+public interface ProjectRepositoryCustom {
+    List<Project> findAllByCompanyId(Long companyId);
+    List<Object[]> findAllByCompanyIdWithMyRole(Long companyId, Long myUserId);
+}

--- a/module-repository/src/main/java/com/welcommu/modulerepository/project/ProjectRepositoryImpl.java
+++ b/module-repository/src/main/java/com/welcommu/modulerepository/project/ProjectRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.welcommu.modulerepository.project;
+
+import com.welcommu.moduledomain.project.Project;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ProjectRepositoryImpl implements ProjectRepositoryCustom{
+
+    private final EntityManager em;
+
+    @Override
+    public List<Project> findAllByCompanyId(Long companyId) {
+        String jpql = """
+            SELECT DISTINCT p
+            FROM Project p
+            JOIN ProjectUser pu ON pu.project = p
+            JOIN User u ON pu.user = u
+            WHERE u.company.id = :companyId
+        """;
+
+        return em.createQuery(jpql, Project.class)
+            .setParameter("companyId", companyId)
+            .getResultList();
+    }
+
+    @Override
+    public List<Object[]> findAllByCompanyIdWithMyRole(Long companyId, Long myUserId) {
+        String jpql = """
+        SELECT p, pu
+        FROM Project p
+        JOIN ProjectUser pu ON pu.project = p
+        JOIN User u ON pu.user = u
+        WHERE u.company.id = :companyId
+    """;
+
+        return em.createQuery(jpql, Object[].class)
+            .setParameter("companyId", companyId)
+            .getResultList();
+    }
+}

--- a/module-repository/src/main/java/com/welcommu/modulerepository/project/ProjectUserRepository.java
+++ b/module-repository/src/main/java/com/welcommu/modulerepository/project/ProjectUserRepository.java
@@ -18,5 +18,6 @@ public interface ProjectUserRepository extends JpaRepository<ProjectUser, Long> 
     List<ProjectUser> findByProject(Project project);
 
     Optional<ProjectUser> findByUserIdAndProjectId(Long userId, Long projectId);
-//    Optional<ProjectUser> findByUserAndProject(User user, Project project);
+
+    List<ProjectUser> findByUserId(Long userId);
 }

--- a/module-service/src/main/java/com/welcommu/moduleservice/project/ProjectService.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/project/ProjectService.java
@@ -1,9 +1,15 @@
 package com.welcommu.moduleservice.project;
 
+import static com.welcommu.modulecommon.exception.CustomErrorCode.NOT_FOUND_COMPANY;
+
 import com.welcommu.modulecommon.exception.CustomErrorCode;
 import com.welcommu.modulecommon.exception.CustomException;
+import com.welcommu.moduledomain.ProjectCompany.ProjectCompany;
+import com.welcommu.moduledomain.company.Company;
 import com.welcommu.moduledomain.company.CompanyRole;
 import com.welcommu.moduledomain.projectprogress.DefaultProjectProgress;
+import com.welcommu.modulerepository.company.CompanyRepository;
+import com.welcommu.modulerepository.project.ProjectCompanyRepository;
 import com.welcommu.moduleservice.project.audit.ProjectAuditService;
 import com.welcommu.moduledomain.project.Project;
 import com.welcommu.moduledomain.projectUser.ProjectUser;
@@ -13,6 +19,7 @@ import com.welcommu.modulerepository.project.ProjectRepository;
 import com.welcommu.modulerepository.project.ProjectUserRepository;
 import com.welcommu.modulerepository.projectprogress.ProjectProgressRepository;
 import com.welcommu.modulerepository.user.UserRepository;
+import com.welcommu.moduleservice.project.dto.ProjectCompanyResponse;
 import com.welcommu.moduleservice.project.dto.ProjectSnapshot;
 import com.welcommu.moduleservice.project.dto.ProjectAdminSummaryResponse;
 import com.welcommu.moduleservice.project.dto.ProjectCreateRequest;
@@ -41,6 +48,8 @@ public class ProjectService {
     private final UserRepository userRepository;
     private final ProjectUserRepository projectUserRepository;
     private final ProjectAuditService projectAuditService;
+    private final ProjectCompanyRepository projectCompanyRepository;
+    private final CompanyRepository companyRepository;
 
     @Transactional
     public void createProject(ProjectCreateRequest dto, Long creatorId) {
@@ -56,12 +65,24 @@ public class ProjectService {
                 .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_USER))
         );
         projectUserRepository.saveAll(participants);
+
+        List<ProjectCompany> projectCompanies = dto.getCompanyIds().stream()
+            .map(companyId -> {
+                Company company = companyRepository.findById(companyId)
+                    .orElseThrow(() -> new CustomException(NOT_FOUND_COMPANY));
+                return ProjectCompany.builder()
+                    .project(createProject)
+                    .company(company)
+                    .build();
+            }).toList();
+
+        projectCompanyRepository.saveAll(projectCompanies);
     }
 
-    public Optional<Project> getProject(User user, Long projectId) {
+    public Project getProject(User user, Long projectId) {
         Project project = projectRepository.findById(projectId).orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_PROJECT));;
         checkUserPermission(user, projectId);
-        return projectRepository.findById(projectId);
+        return project;
 
     }
 
@@ -83,11 +104,26 @@ public class ProjectService {
 
         projectUserRepository.deleteByProject(existingProject);
         projectUserRepository.flush();
+
         List<ProjectUser> updatedUsers = dto.toProjectUsers(existingProject, id ->
             userRepository.findById(id)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_USER))
         );
         projectUserRepository.saveAll(updatedUsers);
+
+        projectCompanyRepository.deleteByProject(existingProject);
+        projectCompanyRepository.flush();
+
+        List<ProjectCompany> updatedCompanies = dto.getCompanyIds().stream()
+            .map(companyId -> {
+                Company company = companyRepository.findById(companyId)
+                    .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_COMPANY));
+                return ProjectCompany.builder()
+                    .project(existingProject)
+                    .company(company)
+                    .build();
+            }).toList();
+        projectCompanyRepository.saveAll(updatedCompanies);
     }
 
 
@@ -165,5 +201,11 @@ public class ProjectService {
             user.getCompany().getCompanyRole() == CompanyRole.ADMIN)) {
             throw new CustomException(CustomErrorCode.NOT_FOUND_PROJECT_USER);
         }
+    }
+
+    public List<ProjectCompanyResponse> getCompaniesByProjectId(Long projectId) {
+        return projectCompanyRepository.findByProjectId(projectId).stream()
+            .map(pc -> ProjectCompanyResponse.from(pc.getCompany()))
+            .toList();
     }
 }

--- a/module-service/src/main/java/com/welcommu/moduleservice/project/dto/ProjectCompanyResponse.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/project/dto/ProjectCompanyResponse.java
@@ -1,0 +1,26 @@
+package com.welcommu.moduleservice.project.dto;
+
+import com.welcommu.moduledomain.company.Company;
+import com.welcommu.moduledomain.company.CompanyRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProjectCompanyResponse {
+    private Long id;
+    private String name;
+    private String businessNumber;
+    private String email;
+    private CompanyRole companyRole;
+
+    public static ProjectCompanyResponse from(Company company) {
+        return new ProjectCompanyResponse(
+            company.getId(),
+            company.getName(),
+            company.getBusinessNumber(),
+            company.getEmail(),
+            company.getCompanyRole()
+        );
+    }
+}

--- a/module-service/src/main/java/com/welcommu/moduleservice/project/dto/ProjectCreateRequest.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/project/dto/ProjectCreateRequest.java
@@ -32,6 +32,9 @@ public class ProjectCreateRequest {
     @NotNull
     private LocalDate endDate;
 
+    @NotNull
+    private List<Long> companyIds;
+
     private List<ProjectUserListCreate> clientManagers;
     private List<ProjectUserListCreate> clientUsers;
     private List<ProjectUserListCreate> devManagers;

--- a/module-service/src/main/java/com/welcommu/moduleservice/project/dto/ProjectModifyRequest.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/project/dto/ProjectModifyRequest.java
@@ -28,6 +28,8 @@ public class ProjectModifyRequest {
     private List<ProjectUserRoleRequest> devManagers;
     private List<ProjectUserRoleRequest> devUsers;
 
+    private List<Long> companyIds;
+
 
     public Project modifyProject(Project project) {
         project.setName(this.name);

--- a/module-service/src/main/java/com/welcommu/moduleservice/project/dto/ProjectSummaryWithRoleDto.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/project/dto/ProjectSummaryWithRoleDto.java
@@ -1,0 +1,30 @@
+package com.welcommu.moduleservice.project.dto;
+
+import com.welcommu.moduledomain.project.Project;
+import com.welcommu.moduledomain.projectUser.ProjectUser;
+import io.micrometer.common.lang.Nullable;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProjectSummaryWithRoleDto {
+    private Long projectId;
+    private String projectName;
+    private String description;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String myRole;  // null 이면 내가 참여하지 않은 프로젝트
+
+    public static ProjectSummaryWithRoleDto from(Project project, @Nullable ProjectUser projectUser) {
+        return new ProjectSummaryWithRoleDto(
+            project.getId(),
+            project.getName(),
+            project.getDescription(),
+            project.getStartDate(),
+            project.getEndDate(),
+            projectUser != null ? projectUser.getProjectUserManageRole().name() : null
+        );
+    }
+}


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목 형식은 "[type] 제목"으로 통일합니다. -->
<!-- 사용하지 않는 항목은 지워주세요.-->

>어떻게 써야 할지 고민될 땐 [Wiki Link](https://github.com/Kernel360/KDEV4-VIVIM-BE/wiki/PR-EXAMPLE-:-%ED%92%80-%EB%A6%AC%ED%80%98%EC%8A%A4%ED%8A%B8-%EC%96%B4%EB%96%BB%EA%B2%8C-%EC%93%B0%EB%A9%B4-%EC%A2%8B%EC%9D%84%EA%B9%8C%3F)를 참고해주세요.

---

## 관련 이슈
<!-- 기입 예 : #3 -->
#18 
<br>

---

## 변경 사항
<!--코드 변경 이유까지 작성할 것-->
<!--관련 스크린샷이 있다면 첨부할 것-->

<!-- [ ] 기입 예 : 로그인 체크 처리가 안 되는 버그를 수정 -->

요청을 보내는 User 소속 회사의 Project List를 응답해주는 기능을 구현하였습니다.

RFP 상으로 개발사는 속하지 못한 프로젝트도 화면에 나타나지만 세부 조회는 불가능해야한다는 요구 사항이 있었습니다.
따라서, 해당 요구사항에 필요한 API 를 구현하였습니다.


```java

@Override
    public List<Object[]> findAllByCompanyIdWithMyRole(Long companyId, Long myUserId) {
        String jpql = """
        SELECT p, pu
        FROM Project p
        JOIN ProjectUser pu ON pu.project = p
        JOIN User u ON pu.user = u
        WHERE u.company.id = :companyId
    """;

        return em.createQuery(jpql, Object[].class)
            .setParameter("companyId", companyId)
            .getResultList();
    }
```

위 Custom Repository 메서드를 사용하여 요청을 보낸 User의 소속 회사가 참여한 프로젝트를 조회하고
해당 User가 프로젝트에 참여하고 있다면 참여 역할까지 리턴해주는 쿼리를 구성하였습니다.

<br>

---

## 추후 개선 및 해결 예정
<!--발견된 위험이나 장애, 더 개선되었으면 좋겠는 부분, 기능적으로 추가되었으면 하는 것, etc.-->
<!-- [ ] 기입 예 : 리액트 적용을 위한 환경설정 필요, 로그인 보안 이슈 보완 예정 -->

> 중요한 내용은 이슈에도 기입해주세요.

<br>

---

## 확인 사항

- [x] 포스트맨/스웨거 확인 여부
- [ ] 테스트 코드 작성 여부
- [ ] 프론트엔드 연동 여부
- [ ] 배포 여부

<br>

---