### PR TITLE
[refactor] #126 AuditLogSearch시 과도하게 시간이 소모되는 현상(N+1) 트러블 슈팅 + ExecutionTimeLogger 적용 + auditLog 페이징 적용

### DIFF
--- a/module-api/src/main/java/com/welcommu/moduleapi/aop/ExecutionTimeLogger.java
+++ b/module-api/src/main/java/com/welcommu/moduleapi/aop/ExecutionTimeLogger.java
@@ -1,0 +1,25 @@
+package com.welcommu.moduleapi.aop;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class ExecutionTimeLogger {
+    @Around("execution(* com.welcommu.moduleapi..*Controller.*(..)) || execution(* com.welcommu.moduleservice..*Service.*(..))")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+
+        Object result = joinPoint.proceed();
+
+        long duration = System.currentTimeMillis() - start;
+        log.info("⏱️ {} executed in {} ms", joinPoint.getSignature(), duration);
+
+        return result;
+    }
+}

--- a/module-api/src/main/java/com/welcommu/moduleapi/aop/ExecutionTimeLogger.java
+++ b/module-api/src/main/java/com/welcommu/moduleapi/aop/ExecutionTimeLogger.java
@@ -1,25 +1,32 @@
 package com.welcommu.moduleapi.aop;
 
-
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.aspectj.lang.annotation.Around;
-import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.*;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Aspect
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class ExecutionTimeLogger {
+
+    @Value("${logging.execution-time.enabled:false}")
+    private boolean enabled;
+
     @Around("execution(* com.welcommu.moduleapi..*Controller.*(..)) || execution(* com.welcommu.moduleservice..*Service.*(..))")
     public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        if (!enabled) {
+            return joinPoint.proceed();
+        }
+
         long start = System.currentTimeMillis();
-
         Object result = joinPoint.proceed();
-
         long duration = System.currentTimeMillis() - start;
-        log.info("⏱️ {} executed in {} ms", joinPoint.getSignature(), duration);
 
+        log.info("⏱️ {} executed in {} ms", joinPoint.getSignature(), duration);
         return result;
     }
 }

--- a/module-api/src/main/java/com/welcommu/moduleapi/logging/AuditLogController.java
+++ b/module-api/src/main/java/com/welcommu/moduleapi/logging/AuditLogController.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,15 +38,16 @@ public class AuditLogController {
 
     @GetMapping("/search")
     @Operation(summary = "감사 로그 검색")
-    public ResponseEntity<Map<String, List<AuditLogResponse>>> searchAuditLogs(
+    public ResponseEntity<Page<AuditLogResponse>> searchAuditLogs(
         @RequestParam(required = false) ActionType actionType,
         @RequestParam(required = false) TargetType entityType,
         @RequestParam(required = false) String startDate,
         @RequestParam(required = false) String endDate,
-        @RequestParam(required = false) Long userId
+        @RequestParam(required = false) Long userId,
+        Pageable pageable
     ) {
-        List<AuditLogResponse> logs = auditLogSearchService.searchLogs(actionType, entityType, startDate, endDate, userId);
-        return ResponseEntity.ok(Map.of("logs", logs));
+        Page<AuditLogResponse> logs = auditLogSearchService.searchLogs(actionType, entityType, startDate, endDate, userId, pageable);
+        return ResponseEntity.ok(logs);
     }
 
 }

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -26,6 +26,8 @@ spring:
 logging:
   level:
     org.springframework.security: DEBUG
+  execution-time:
+    enabled: false
 server:
   port: 443
   ssl:

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -25,6 +25,9 @@ spring:
 logging:
   level:
     org.springframework.security: DEBUG
+  execution-time:
+    enabled: false
+
 server:
   port: 443
   ssl:

--- a/module-infra/src/main/java/com/welcommu/moduleinfra/logging/AuditLogRepositoryCustom.java
+++ b/module-infra/src/main/java/com/welcommu/moduleinfra/logging/AuditLogRepositoryCustom.java
@@ -3,15 +3,19 @@ package com.welcommu.moduleinfra.logging;
 import com.welcommu.moduledomain.logging.AuditLog;
 import com.welcommu.moduledomain.logging.enums.ActionType;
 import com.welcommu.moduledomain.logging.enums.TargetType;
+
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface AuditLogRepositoryCustom {
-    List<AuditLog> findByConditions(
+    Page<AuditLog> findByConditions(
         ActionType actionType,
         TargetType targetType,
         LocalDateTime startDate,
         LocalDateTime endDate,
-        Long userId
+        Long userId,
+        Pageable pageable
     );
 }

--- a/module-infra/src/main/java/com/welcommu/moduleinfra/logging/AuditLogRepositoryImpl.java
+++ b/module-infra/src/main/java/com/welcommu/moduleinfra/logging/AuditLogRepositoryImpl.java
@@ -26,7 +26,7 @@ public class AuditLogRepositoryImpl implements AuditLogRepositoryCustom {
         LocalDateTime endDate,
         Long userId
     ) {
-        StringBuilder sb = new StringBuilder("SELECT a FROM AuditLog a WHERE 1=1");
+        StringBuilder sb = new StringBuilder("SELECT DISTINCT a FROM AuditLog a LEFT JOIN FETCH a.details WHERE 1=1");
         Map<String, Object> params = new HashMap<>();
 
         if (actionType != null) {

--- a/module-infra/src/main/java/com/welcommu/moduleinfra/logging/AuditLogRepositoryImpl.java
+++ b/module-infra/src/main/java/com/welcommu/moduleinfra/logging/AuditLogRepositoryImpl.java
@@ -10,6 +10,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -19,41 +22,56 @@ public class AuditLogRepositoryImpl implements AuditLogRepositoryCustom {
     private final EntityManager em;
 
     @Override
-    public List<AuditLog> findByConditions(
+    public Page<AuditLog> findByConditions(
         ActionType actionType,
         TargetType targetType,
         LocalDateTime startDate,
         LocalDateTime endDate,
-        Long userId
+        Long userId,
+        Pageable pageable
     ) {
-        StringBuilder sb = new StringBuilder("SELECT DISTINCT a FROM AuditLog a LEFT JOIN FETCH a.details WHERE 1=1");
+        StringBuilder jpql = new StringBuilder("SELECT DISTINCT a FROM AuditLog a LEFT JOIN FETCH a.details WHERE 1=1");
+        StringBuilder countJpql = new StringBuilder("SELECT COUNT(DISTINCT a) FROM AuditLog a WHERE 1=1");
         Map<String, Object> params = new HashMap<>();
 
         if (actionType != null) {
-            sb.append(" AND a.actionType = :actionType");
+            jpql.append(" AND a.actionType = :actionType");
+            countJpql.append(" AND a.actionType = :actionType");
             params.put("actionType", actionType);
         }
         if (targetType != null) {
-            sb.append(" AND a.targetType = :targetType");
+            jpql.append(" AND a.targetType = :targetType");
+            countJpql.append(" AND a.targetType = :targetType");
             params.put("targetType", targetType);
         }
         if (startDate != null) {
-            sb.append(" AND a.loggedAt >= :startDate");
+            jpql.append(" AND a.loggedAt >= :startDate");
+            countJpql.append(" AND a.loggedAt >= :startDate");
             params.put("startDate", startDate);
         }
         if (endDate != null) {
-            sb.append(" AND a.loggedAt <= :endDate");
+            jpql.append(" AND a.loggedAt <= :endDate");
+            countJpql.append(" AND a.loggedAt <= :endDate");
             params.put("endDate", endDate);
         }
         if (userId != null) {
-            sb.append(" AND a.actorId = :userId");
+            jpql.append(" AND a.actorId = :userId");
+            countJpql.append(" AND a.actorId = :userId");
             params.put("userId", userId);
         }
 
-        TypedQuery<AuditLog> query = em.createQuery(sb.toString(), AuditLog.class);
+        TypedQuery<AuditLog> query = em.createQuery(jpql.toString(), AuditLog.class);
         params.forEach(query::setParameter);
+        query.setFirstResult((int) pageable.getOffset());
+        query.setMaxResults(pageable.getPageSize());
 
-        return query.getResultList();
+        List<AuditLog> results = query.getResultList();
+
+        TypedQuery<Long> countQuery = em.createQuery(countJpql.toString(), Long.class);
+        params.forEach(countQuery::setParameter);
+        Long total = countQuery.getSingleResult();
+
+        return new PageImpl<>(results, pageable, total);
     }
 }
 

--- a/module-service/src/main/java/com/welcommu/moduleservice/logging/AuditLogSearchService.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/logging/AuditLogSearchService.java
@@ -10,6 +10,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,21 +25,21 @@ public class AuditLogSearchService {
             .toList();
     }
 
-    public List<AuditLogResponse> searchLogs(
+    public Page<AuditLogResponse>searchLogs(
         ActionType actionType,
         TargetType targetType,
         String startDate,
         String endDate,
-        Long userId
+        Long userId,
+        Pageable pageable
     ) {
         LocalDateTime start = (startDate != null) ? LocalDate.parse(startDate).atStartOfDay() : null;
         LocalDateTime end = (endDate != null) ? LocalDate.parse(endDate).atTime(LocalTime.MAX) : null;
 
-        List<AuditLog> logs = auditLogRepository.findByConditions(actionType, targetType, start, end, userId);
-
-        return logs.stream()
-            .map(AuditLogResponse::from)
-            .toList();
+        Page<AuditLog> logs = auditLogRepository.findByConditions(
+            actionType, targetType, start, end, userId, pageable
+        );
+        return logs.map(AuditLogResponse::from);
     }
 
 }


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목 형식은 "[type] 제목"으로 통일합니다. -->
<!-- 사용하지 않는 항목은 지워주세요.-->

>어떻게 써야 할지 고민될 땐 [Wiki Link](https://github.com/Kernel360/KDEV4-VIVIM-BE/wiki/PR-EXAMPLE-:-%ED%92%80-%EB%A6%AC%ED%80%98%EC%8A%A4%ED%8A%B8-%EC%96%B4%EB%96%BB%EA%B2%8C-%EC%93%B0%EB%A9%B4-%EC%A2%8B%EC%9D%84%EA%B9%8C%3F)를 참고해주세요.

---

## 관련 이슈
<!-- 기입 예 : #3 -->
#126 
<br>

---

## 변경 사항
<!--코드 변경 이유까지 작성할 것-->
<!--관련 스크린샷이 있다면 첨부할 것-->

<!-- [ ] 기입 예 : 로그인 체크 처리가 안 되는 버그를 수정 -->
public class AuditLogRepositoryImpl 에서 jpql로 보내던 쿼리 수정

```java
BEFORE
StringBuilder sb = new StringBuilder("SELECT a FROM AuditLog a WHERE 1=1");

AFTER        
StringBuilder sb = new StringBuilder("SELECT DISTINCT a FROM AuditLog a LEFT JOIN FETCH a.details WHERE 1=1");
```

ExecutionTimeLogger 기능 추가

default는 비활성화 되어 있음

auditLog 에 페이징 기능을 추가하였습니다.

활성화 시
```bash
2025-04-25 15:04:38.410 [https-jsse-nio-443-exec-10]  INFO com.welcommu.moduleapi.aop.ExecutionTimeLogger - ⏱️ List com.welcommu.moduleservice.logging.AuditLogSearchService.searchLogs(ActionType,TargetType,String,String,Long) executed in 48 ms
2025-04-25 15:04:38.411 [https-jsse-nio-443-exec-10]  INFO com.welcommu.moduleapi.aop.ExecutionTimeLogger - ⏱️ ResponseEntity com.welcommu.moduleapi.logging.AuditLogController.searchAuditLogs(ActionType,TargetType,String,String,Long) executed in 50 ms
```

위와 같이 요청응답에 걸린 시간이 콘솔에 표시됨

활성화를 원할 경우

application-loacl.yml에서
```yml

logging:
  level:
    org.springframework.security: DEBUG
  execution-time:
    enabled: true  <- flase 에서 true 로
```

enabled 를 false 에서 true 로 수정하면 됩니다.

<br>

---

## 추후 개선 및 해결 예정
<!--발견된 위험이나 장애, 더 개선되었으면 좋겠는 부분, 기능적으로 추가되었으면 하는 것, etc.-->
<!-- [ ] 기입 예 : 리액트 적용을 위한 환경설정 필요, 로그인 보안 이슈 보완 예정 -->

> 중요한 내용은 이슈에도 기입해주세요.

<br>

---

## 확인 사항

- [x] 포스트맨/스웨거 확인 여부
- [ ] 테스트 코드 작성 여부
- [ ] 프론트엔드 연동 여부
- [ ] 배포 여부

<br>

---

## 트러블 슈팅

### 배경
> 트러블슈팅이 발생한 상황
#### 관리자 권한으로 감사로그 페이지 진입 시 비정상적이게 응답시간이 오래걸리는 상황 발생
![Screenshot 2025-04-25 at 2 32 28 PM](https://github.com/user-attachments/assets/ee7d3caf-1ffb-49c9-86dd-7948b6587f73)

Spring AOP 를 활용해 요청응답시간을 확인해본 결과 
```bash
2025-04-25 11:58:29.609 [https-jsse-nio-443-exec-6]  INFO com.welcommu.moduleapi.aop.ExecutionTimeLogger - ⏱️ List com.welcommu.moduleservice.logging.AuditLogSearchService.searchLogs(ActionType,TargetType,String,String,Long) executed in 1912 ms
2025-04-25 11:58:29.609 [https-jsse-nio-443-exec-6]  INFO com.welcommu.moduleapi.aop.ExecutionTimeLogger - ⏱️ ResponseEntity com.welcommu.moduleapi.logging.AuditLogController.searchAuditLogs(ActionType,TargetType,String,String,Long) executed in 1912 ms
```

로컬 환경에서의 단일 조회임에도 1912ms가 소모된다는 사실을 확인함



### 이슈
<!-- 수정 코드 없을 경우 빈 코드란 지울 것 -->
> 관련 스크린샷이 있다면 첨부할 것

```java
StringBuilder sb = new StringBuilder("SELECT a FROM AuditLog a WHERE 1=1");
```

### 원인 분석
![ChatGPT Image 2025년 4월 25일 오후 02_37_49](https://github.com/user-attachments/assets/bd367a9a-721b-4af2-8a49-9066126a34ab)

위와 같은 연관관계를 가진 테이블 사이에서

```java
@Entity
public class AuditLog {
    @OneToMany(mappedBy = "auditLog", fetch = FetchType.LAZY)
    private List<AuditLogDetail> details;
}
```

기본적으로 details는 지연 로딩(LAZY) 방식으로 설정되어 있음


AuditLogResponse dto 에서

```java
public class AuditLogResponse {

    private Long id;
    private Long actorId;
    private String targetType;
    private Long targetId;
    private String actionType;
    private LocalDateTime loggedAt;
    private List<AuditLogDetailResponse> details;

    public static AuditLogResponse from(AuditLog log) {
        return new AuditLogResponse(
            log.getId(),
            log.getActorId(),
            log.getTargetType().name(),
            log.getTargetId(),
            log.getActionType().name(),
            log.getLoggedAt(),
            log.getDetails().stream().map(AuditLogDetailResponse::from).toList()  <- 문제 발생 부분
        );
    }
}
```

`log.getDetails().stream().map(AuditLogDetailResponse::from).toList() 
`

에서 N + 1 문제가 발생

각 AuditLog 마다 details를 가져오기 위해 별도 쿼리가 실행됨

→ 총 N개의 추가 쿼리 발생

결과

audit_log에 대한 쿼리: 1회

audit_log_detail에 대한 쿼리: audit_log 개수만큼 추가 실행

예: 50개의 AuditLog → audit_log_detail SELECT 50회


요약

```
[Controller]
    ↓
[Service: getAllLogs() / searchLogs()]
    ↓
[Repository: findByConditions() ← LAZY 상태]
    ↓
[DTO 변환 시: log.getDetails() 호출]
    ↓
 audit_log_detail N회 SELECT 쿼리 → N+1 발생
```



### 수정 코드 또는 해결 방법
<!-- 수정 코드 없을 경우 빈 코드란 지울 것 -->
> 관련 스크린샷이 있다면 첨부할 것

현재 문제는 DTO에서 log.getDetails()를 순회하는데, fetch join 없이 LAZY 필드라서 생기는 문제였음

public class AuditLogRepositoryImpl 에서 jpql로 보내던 쿼리를 수정하여 N + 1문제를 해결함

```java
String jpql = """
    SELECT DISTINCT a FROM AuditLog a
    LEFT JOIN FETCH a.details
    WHERE ...
""";
```

### 트러블 슈팅 전후 응답시간 비교

항목 | Before (N+1 발생) | After (fetch join 적용)
-- | -- | --
쿼리 수 | 약 1 + N (ex. 51회) | 1회 (JOIN 1회)
응답 시간 | 평균 1900ms | 평균 50ms
SQL 로그 | SELECT FROM audit_log + N x SELECT FROM audit_log_detail | SELECT ... FROM audit_log LEFT JOIN audit_log_detail


<!-- notionvc: 23d5c78f-5a61-4569-a392-e1e04b867fbd -->

### 결론

응답 속도: 1900ms → 50ms

총 1850ms 단축되었고, 약 **97.4% 성능 개선**을 달성함.

N+1 문제 제거(fetched join 적용) 덕분에 DB 접근 횟수가 대폭 감소했고, 그 결과 전체 API 응답 시간이 크게 줄어듦.
