### PR TITLE
[refactor] #120 ProjectPost, ProjectPostComment Service 인터페이스 분리

### DIFF
--- a/module-service/src/main/java/com/welcommu/moduleservice/projectpost/ProjectPostCommentService.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/projectpost/ProjectPostCommentService.java
@@ -1,92 +1,20 @@
 package com.welcommu.moduleservice.projectpost;
 
-import com.welcommu.modulecommon.exception.CustomErrorCode;
 import com.welcommu.modulecommon.exception.CustomException;
-import com.welcommu.moduledomain.company.CompanyRole;
-import com.welcommu.moduledomain.projectpost.ProjectPost;
-import com.welcommu.moduledomain.projectpost.ProjectPostComment;
 import com.welcommu.moduledomain.user.User;
-import com.welcommu.moduleinfra.project.ProjectUserRepository;
-import com.welcommu.moduleinfra.projectpost.ProjectPostCommentRepository;
-import com.welcommu.moduleinfra.projectpost.ProjectPostRepository;
-import com.welcommu.moduleservice.projectpost.audit.ProjectPostCommentAuditService;
 import com.welcommu.moduleservice.projectpost.dto.ProjectPostCommentListResponse;
 import com.welcommu.moduleservice.projectpost.dto.ProjectPostCommentRequest;
-import com.welcommu.moduleservice.projectpost.dto.ProjectPostCommentSnapshot;
 import java.util.List;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
-public class ProjectPostCommentService {
+public interface ProjectPostCommentService {
 
-    private final ProjectPostCommentRepository projectPostCommentRepository;
-    private final ProjectPostRepository projectPostRepository;
-    private final ProjectUserRepository projectUserRepository;
-    private final ProjectPostCommentAuditService projectPostCommentAuditService;
+    void createComment(User user, Long postId, ProjectPostCommentRequest request, String clientIp)
+        throws CustomException;
 
-    @Transactional
-    public void createComment(User user, Long postId, ProjectPostCommentRequest request,
-        String clientIp) {
-        ProjectPostComment newComment = request.toEntity(user, postId, request, clientIp);
-        ProjectPost post = projectPostRepository.findById(postId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_POST));
+    void modifyComment(User user, Long postId, Long commentId, ProjectPostCommentRequest request)
+        throws CustomException;
 
-        checkUserPermission(user, post.getProject().getId());
+    List<ProjectPostCommentListResponse> getCommentList(Long projectPostId);
 
-        Long creatorId = user.getId();
-        ProjectPostComment savedComment = projectPostCommentRepository.save(newComment);
-        projectPostCommentAuditService.createAuditLog(ProjectPostCommentSnapshot.from(savedComment),
-            creatorId);
-    }
-
-    @Transactional
-    public void modifyComment(User user, Long postId, Long commentId,
-        ProjectPostCommentRequest request) {
-
-        ProjectPostComment existingComment = projectPostCommentRepository.findById(commentId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_COMMENT));
-
-        Long modifierId = user.getId();
-
-        ProjectPostCommentSnapshot beforeSnapshot = ProjectPostCommentSnapshot.from(
-            existingComment);
-
-        existingComment.setContent(request.getContent());
-        existingComment.setModifiedAt();
-
-        ProjectPostCommentSnapshot afterSnapshot = ProjectPostCommentSnapshot.from(existingComment);
-        projectPostCommentAuditService.modifyAuditLog(beforeSnapshot, afterSnapshot, modifierId);
-    }
-
-    @Transactional(readOnly = true)
-    public List<ProjectPostCommentListResponse> getCommentList(Long projectPostId) {
-        List<ProjectPostComment> comments = projectPostCommentRepository.findAllByProjectPostIdAndDeletedAtIsNull(
-            projectPostId);
-        return comments.stream()
-            .map(ProjectPostCommentListResponse::from)
-            .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public void deleteComment(User user, Long postId, Long commentId) {
-        ProjectPostComment existingComment = projectPostCommentRepository.findById(commentId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_COMMENT));
-        existingComment.setDeletedAt();
-
-        Long deleterId = user.getId();
-
-        projectPostCommentAuditService.deleteAuditLog(
-            ProjectPostCommentSnapshot.from(existingComment), deleterId);
-    }
-
-    private void checkUserPermission(User user, Long projectId) {
-        if (projectUserRepository.findByUserIdAndProjectId(user.getId(), projectId).isEmpty() && !(
-            user.getCompany().getCompanyRole() == CompanyRole.ADMIN)) {
-            throw new CustomException(CustomErrorCode.NOT_FOUND_PROJECT_USER);
-        }
-    }
+    void deleteComment(User user, Long postId, Long commentId) throws CustomException;
 }

--- a/module-service/src/main/java/com/welcommu/moduleservice/projectpost/ProjectPostCommentServiceImpl.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/projectpost/ProjectPostCommentServiceImpl.java
@@ -1,0 +1,86 @@
+package com.welcommu.moduleservice.projectpost;
+
+import com.welcommu.modulecommon.exception.CustomErrorCode;
+import com.welcommu.modulecommon.exception.CustomException;
+import com.welcommu.moduledomain.company.CompanyRole;
+import com.welcommu.moduledomain.projectpost.ProjectPost;
+import com.welcommu.moduledomain.projectpost.ProjectPostComment;
+import com.welcommu.moduledomain.user.User;
+import com.welcommu.moduleinfra.project.ProjectUserRepository;
+import com.welcommu.moduleinfra.projectpost.ProjectPostCommentRepository;
+import com.welcommu.moduleinfra.projectpost.ProjectPostRepository;
+import com.welcommu.moduleservice.projectpost.audit.ProjectPostCommentAuditService;
+import com.welcommu.moduleservice.projectpost.dto.ProjectPostCommentListResponse;
+import com.welcommu.moduleservice.projectpost.dto.ProjectPostCommentRequest;
+import com.welcommu.moduleservice.projectpost.dto.ProjectPostCommentSnapshot;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class ProjectPostCommentServiceImpl implements ProjectPostCommentService {
+
+    private final ProjectPostCommentRepository projectPostCommentRepository;
+    private final ProjectPostRepository projectPostRepository;
+    private final ProjectUserRepository projectUserRepository;
+    private final ProjectPostCommentAuditService projectPostCommentAuditService;
+
+    @Override
+    @Transactional
+    public void createComment(User user, Long postId, ProjectPostCommentRequest request,
+        String clientIp) {
+        ProjectPostComment newComment = request.toEntity(user, postId, request, clientIp);
+        ProjectPost post = projectPostRepository.findById(postId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_POST));
+        checkUserPermission(user, post.getProject().getId());
+        ProjectPostComment savedComment = projectPostCommentRepository.save(newComment);
+        projectPostCommentAuditService.createAuditLog(
+            ProjectPostCommentSnapshot.from(savedComment), user.getId());
+    }
+
+    @Override
+    @Transactional
+    public void modifyComment(User user, Long postId, Long commentId,
+        ProjectPostCommentRequest request) {
+        ProjectPostComment existingComment = projectPostCommentRepository.findById(commentId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_COMMENT));
+        ProjectPostCommentSnapshot before = ProjectPostCommentSnapshot.from(existingComment);
+        existingComment.setContent(request.getContent());
+        existingComment.setModifiedAt();
+        projectPostCommentAuditService.modifyAuditLog(
+            before, ProjectPostCommentSnapshot.from(existingComment), user.getId());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ProjectPostCommentListResponse> getCommentList(Long projectPostId) {
+        return projectPostCommentRepository
+            .findAllByProjectPostIdAndDeletedAtIsNull(projectPostId)
+            .stream()
+            .map(ProjectPostCommentListResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void deleteComment(User user, Long postId, Long commentId) {
+        ProjectPostComment existingComment = projectPostCommentRepository.findById(commentId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_COMMENT));
+        existingComment.setDeletedAt();
+        projectPostCommentAuditService.deleteAuditLog(
+            ProjectPostCommentSnapshot.from(existingComment), user.getId());
+    }
+
+    private void checkUserPermission(User user, Long projectId) {
+        boolean isMember = projectUserRepository
+            .findByUserIdAndProjectId(user.getId(), projectId)
+            .isPresent();
+        if (!isMember && user.getCompany().getCompanyRole() != CompanyRole.ADMIN) {
+            throw new CustomException(CustomErrorCode.NOT_FOUND_PROJECT_USER);
+        }
+    }
+}

--- a/module-service/src/main/java/com/welcommu/moduleservice/projectpost/ProjectPostService.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/projectpost/ProjectPostService.java
@@ -1,108 +1,30 @@
 package com.welcommu.moduleservice.projectpost;
 
-import com.welcommu.modulecommon.exception.CustomErrorCode;
 import com.welcommu.modulecommon.exception.CustomException;
-import com.welcommu.moduledomain.project.Project;
-import com.welcommu.moduledomain.projectpost.ProjectPost;
 import com.welcommu.moduledomain.user.User;
-import com.welcommu.moduleinfra.project.ProjectUserRepository;
-import com.welcommu.moduleinfra.project.ProjectRepository;
-import com.welcommu.moduleinfra.projectpost.ProjectPostRepository;
-import com.welcommu.moduleservice.projectpost.audit.ProjectPostAuditService;
 import com.welcommu.moduleservice.projectpost.dto.ProjectPostDetailResponse;
 import com.welcommu.moduleservice.projectpost.dto.ProjectPostListResponse;
 import com.welcommu.moduleservice.projectpost.dto.ProjectPostRequest;
-import com.welcommu.moduleservice.projectpost.dto.ProjectPostSnapshot;
 import com.welcommu.moduleservice.projectpost.dto.RecentUserPostListRequest;
 import java.util.List;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
-public class ProjectPostService {
+public interface ProjectPostService {
 
-    private final ProjectPostRepository projectPostRepository;
-    private final ProjectUserRepository projectUserRepository;
-    private final ProjectRepository projectRepository;
-    private final ProjectPostAuditService projectPostAuditService;
+    Long createPost(User user, Long projectId, ProjectPostRequest request, String clientIp,
+        Long creatorId) throws CustomException;
 
-    @Transactional
-    public Long createPost(User user, Long projectId, ProjectPostRequest request, String clientIp,
-        Long creatorId) {
-        Project project = projectRepository.findById(projectId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_PROJECT));
-        ProjectPost newPost = request.toEntity(user, project, request, clientIp);
+    void modifyPost(Long projectId, Long postId, ProjectPostRequest request,
+        Long modifierId) throws CustomException;
 
-        ProjectPost savedPost = projectPostRepository.save(newPost);
+    List<ProjectPostListResponse> getPostList(Long projectId);
 
-        projectPostAuditService.createAuditLog(ProjectPostSnapshot.from(savedPost), creatorId);
-        return savedPost.getId();
-    }
+    List<ProjectPostListResponse> getRecentPostList();
 
-    @Transactional
-    public void modifyPost(Long projectId, Long postId, ProjectPostRequest request,
-        Long modifierId) {
+    List<ProjectPostListResponse> getRecentUserPostList(RecentUserPostListRequest request);
 
-        ProjectPost existingPost = projectPostRepository.findById(postId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_POST));
-        ProjectPostSnapshot beforeSnapshot = ProjectPostSnapshot.from(existingPost);
+    ProjectPostDetailResponse getPostDetail(Long projectId, Long postId) throws CustomException;
 
-        existingPost.setTitle(request.getTitle());
-        existingPost.setContent(request.getContent());
-        existingPost.setProjectPostStatus(request.getProjectPostStatus());
-        existingPost.setModifiedAt();
+    void deletePost(Long projectId, Long postId, Long deleterId) throws CustomException;
 
-        ProjectPostSnapshot afterSnapshot = ProjectPostSnapshot.from(existingPost);
-
-        projectPostAuditService.modifyAuditLog(beforeSnapshot, afterSnapshot, modifierId);
-    }
-
-
-    public List<ProjectPostListResponse> getPostList(Long projectId) {
-        List<ProjectPost> posts = projectPostRepository.findAllByProjectIdAndDeletedAtIsNull(
-            projectId);
-
-        return posts.stream()
-            .map(ProjectPostListResponse::from)
-            .collect(Collectors.toList());
-    }
-
-    public List<ProjectPostListResponse> getRecentPostList() {
-        List<ProjectPost> posts = projectPostRepository.findTop5RecentPostsByDeletedAtIsNullOrderByCreatedAtDesc();
-
-        return posts.stream()
-            .map(ProjectPostListResponse::from)
-            .collect(Collectors.toList());
-    }
-
-    public List<ProjectPostListResponse> getRecentUserPostList(RecentUserPostListRequest request) {
-        return request.getRecentUserPostList(projectUserRepository, projectPostRepository);
-    }
-
-
-    @Transactional(readOnly = true)
-    public ProjectPostDetailResponse getPostDetail(Long projectId, Long postId) {
-        ProjectPost existingPost = projectPostRepository.findById(postId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_POST));
-
-        return ProjectPostDetailResponse.from(existingPost);
-    }
-
-    @Transactional
-    public void deletePost(Long projectId, Long postId, Long deleterId) {
-        ProjectPost existingPost = projectPostRepository.findById(postId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_POST));
-        existingPost.setDeletedAt();
-        projectPostAuditService.deleteAuditLog(ProjectPostSnapshot.from(existingPost), deleterId);
-    }
-
-    @Transactional
-    public void completeAnswer(Long postId, String answer) {
-        ProjectPost existingPost = projectPostRepository.findById(postId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_POST));
-        existingPost.setResponseToQuestion(answer);
-    }
+    void completeAnswer(Long postId, String answer) throws CustomException;
 }

--- a/module-service/src/main/java/com/welcommu/moduleservice/projectpost/ProjectPostServiceImpl.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/projectpost/ProjectPostServiceImpl.java
@@ -1,0 +1,108 @@
+package com.welcommu.moduleservice.projectpost;
+
+import com.welcommu.modulecommon.exception.CustomErrorCode;
+import com.welcommu.modulecommon.exception.CustomException;
+import com.welcommu.moduledomain.project.Project;
+import com.welcommu.moduledomain.projectpost.ProjectPost;
+import com.welcommu.moduledomain.user.User;
+import com.welcommu.moduleinfra.project.ProjectRepository;
+import com.welcommu.moduleinfra.project.ProjectUserRepository;
+import com.welcommu.moduleinfra.projectpost.ProjectPostRepository;
+import com.welcommu.moduleservice.projectpost.audit.ProjectPostAuditService;
+import com.welcommu.moduleservice.projectpost.dto.ProjectPostDetailResponse;
+import com.welcommu.moduleservice.projectpost.dto.ProjectPostListResponse;
+import com.welcommu.moduleservice.projectpost.dto.ProjectPostRequest;
+import com.welcommu.moduleservice.projectpost.dto.ProjectPostSnapshot;
+import com.welcommu.moduleservice.projectpost.dto.RecentUserPostListRequest;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectPostServiceImpl implements ProjectPostService {
+
+    private final ProjectPostRepository projectPostRepository;
+    private final ProjectUserRepository projectUserRepository;
+    private final ProjectRepository projectRepository;
+    private final ProjectPostAuditService projectPostAuditService;
+
+    @Override
+    @Transactional
+    public Long createPost(User user, Long projectId, ProjectPostRequest request, String clientIp,
+        Long creatorId) {
+        Project project = projectRepository.findById(projectId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_PROJECT));
+        ProjectPost newPost = request.toEntity(user, project, request, clientIp);
+        ProjectPost savedPost = projectPostRepository.save(newPost);
+        projectPostAuditService.createAuditLog(ProjectPostSnapshot.from(savedPost), creatorId);
+        return savedPost.getId();
+    }
+
+    @Override
+    @Transactional
+    public void modifyPost(Long projectId, Long postId, ProjectPostRequest request,
+        Long modifierId) {
+        ProjectPost existingPost = projectPostRepository.findById(postId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_POST));
+        ProjectPostSnapshot beforeSnapshot = ProjectPostSnapshot.from(existingPost);
+
+        existingPost.setTitle(request.getTitle());
+        existingPost.setContent(request.getContent());
+        existingPost.setProjectPostStatus(request.getProjectPostStatus());
+        existingPost.setModifiedAt();
+
+        ProjectPostSnapshot afterSnapshot = ProjectPostSnapshot.from(existingPost);
+        projectPostAuditService.modifyAuditLog(beforeSnapshot, afterSnapshot, modifierId);
+    }
+
+    @Override
+    public List<ProjectPostListResponse> getPostList(Long projectId) {
+        return projectPostRepository
+            .findAllByProjectIdAndDeletedAtIsNull(projectId)
+            .stream()
+            .map(ProjectPostListResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ProjectPostListResponse> getRecentPostList() {
+        return projectPostRepository
+            .findTop5RecentPostsByDeletedAtIsNullOrderByCreatedAtDesc()
+            .stream()
+            .map(ProjectPostListResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ProjectPostListResponse> getRecentUserPostList(RecentUserPostListRequest request) {
+        return request.getRecentUserPostList(projectUserRepository, projectPostRepository);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProjectPostDetailResponse getPostDetail(Long projectId, Long postId) {
+        ProjectPost existingPost = projectPostRepository.findById(postId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_POST));
+        return ProjectPostDetailResponse.from(existingPost);
+    }
+
+    @Override
+    @Transactional
+    public void deletePost(Long projectId, Long postId, Long deleterId) {
+        ProjectPost existingPost = projectPostRepository.findById(postId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_POST));
+        existingPost.setDeletedAt();
+        projectPostAuditService.deleteAuditLog(ProjectPostSnapshot.from(existingPost), deleterId);
+    }
+
+    @Override
+    @Transactional
+    public void completeAnswer(Long postId, String answer) {
+        ProjectPost existingPost = projectPostRepository.findById(postId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_POST));
+        existingPost.setResponseToQuestion(answer);
+    }
+}


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목 형식은 "[type] 제목"으로 통일합니다. -->
<!-- 사용하지 않는 항목은 지워주세요.-->

>어떻게 써야 할지 고민될 땐 [Wiki Link](https://github.com/Kernel360/KDEV4-VIVIM-BE/wiki/PR-EXAMPLE-:-%ED%92%80-%EB%A6%AC%ED%80%98%EC%8A%A4%ED%8A%B8-%EC%96%B4%EB%96%BB%EA%B2%8C-%EC%93%B0%EB%A9%B4-%EC%A2%8B%EC%9D%84%EA%B9%8C%3F)를 참고해주세요.

---

## 관련 이슈
<!-- 기입 예 : #3 -->
#120 
<br>

---

## 🔧 변경 사항

### ✨ 요약
기존 `ProjectPostController`, `ProjectPostCommentController`가 서비스 구현체인 `ProjectPostServiceImpl`, `ProjectPostCommentServiceImpl`에 직접 의존하고 있어,  
DIP(Dependency Inversion Principle, 의존성 역전 원칙)을 위배하는 구조였습니다.

이에 따라 비즈니스 로직을 추상화한 인터페이스를 도입하고, Controller가 구현체가 아닌 인터페이스에 의존하도록 리팩토링하였습니다.

---

### 🧠 설계 의도

- DIP 원칙 실현
  : 상위 계층(Controller)은 하위 구현체가 아닌 추상화(인터페이스)에 의존해야 하며,  
  변경에 대한 유연성을 확보할 수 있도록 구조를 개선하였습니다.

- 테스트 및 확장성 향상
  : 인터페이스 기반으로 구조를 변경함으로써  
  테스트 시 Mock 객체 주입이 가능해지고,  
  구현체 교체도 용이해졌습니다.

---

## 확인 사항

- [x] 포스트맨/스웨거 확인 여부
- [ ] 테스트 코드 작성 여부
- [x] 프론트엔드 연동 여부
- [x] 배포 여부

<br>

---