### PR TITLE
[refactor] #120 AdminInquiryService, AdminInquiryCommentService 인터페이스 분리

### DIFF
--- a/module-service/src/main/java/com/welcommu/moduleservice/admininquiry/AdminInquiryCommentService.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/admininquiry/AdminInquiryCommentService.java
@@ -1,60 +1,20 @@
 package com.welcommu.moduleservice.admininquiry;
 
-
-import com.welcommu.modulecommon.exception.CustomErrorCode;
 import com.welcommu.modulecommon.exception.CustomException;
-import com.welcommu.moduledomain.admininquiry.AdminInquiry;
-import com.welcommu.moduledomain.admininquiry.AdminInquiryComment;
 import com.welcommu.moduledomain.user.User;
-import com.welcommu.moduleinfra.admininquiry.AdminInquiryCommentRepository;
-import com.welcommu.moduleinfra.admininquiry.AdminInquiryRepository;
 import com.welcommu.moduleservice.admininquiry.dto.AdminInquiryCommentListResponse;
 import com.welcommu.moduleservice.admininquiry.dto.AdminInquiryCommentRequest;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
-public class AdminInquiryCommentService {
+public interface AdminInquiryCommentService {
 
-    private final AdminInquiryCommentRepository adminInquiryCommentRepository;
-    private final AdminInquiryRepository adminInquiryRepository;
+    void createAdminInquiryComment(User user, AdminInquiryCommentRequest request, Long inquiryId)
+        throws CustomException;
 
-    public void createAdminInquiryComment(User user,
-        AdminInquiryCommentRequest adminInquiryCommentRequest, Long adminInquiryId) {
-        AdminInquiry existingInquiry = adminInquiryRepository.findById(adminInquiryId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY));
-        AdminInquiryComment newInquiryComment = adminInquiryCommentRequest.toEntity(user,
-            adminInquiryCommentRequest, existingInquiry);
-        adminInquiryCommentRepository.save(newInquiryComment);
-    }
+    void modifyAdminInquiryComment(Long commentId, AdminInquiryCommentRequest request)
+        throws CustomException;
 
-    @Transactional
-    public void modifyAdminInquiryComment(Long commentId,
-        AdminInquiryCommentRequest adminInquiryCommentRequest) {
-        AdminInquiryComment existingInquiryComment = adminInquiryCommentRepository.findById(
-                commentId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY_COMMENT));
-        existingInquiryComment.setContent(adminInquiryCommentRequest.getContent());
-    }
+    List<AdminInquiryCommentListResponse> getAdminInquiryCommentList(Long inquiryId);
 
-    public List<AdminInquiryCommentListResponse> getAdminInquiryCommentList(Long adminInquiryId) {
-        List<AdminInquiryComment> adminInquiryList = adminInquiryCommentRepository.findAllByAdminInquiryIdAndDeletedAtIsNull(
-            adminInquiryId);
-        return adminInquiryList.stream()
-            .map(AdminInquiryCommentListResponse::from)
-            .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public void deleteAdminInquiryComment(Long commentId) {
-        AdminInquiryComment existingInquiryComment = adminInquiryCommentRepository.findById(
-                commentId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY_COMMENT));
-        existingInquiryComment.setDeletedAt(LocalDateTime.now());
-    }
+    void deleteAdminInquiryComment(Long commentId) throws CustomException;
 }

--- a/module-service/src/main/java/com/welcommu/moduleservice/admininquiry/AdminInquiryCommentServiceImpl.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/admininquiry/AdminInquiryCommentServiceImpl.java
@@ -1,0 +1,5 @@
+package com.welcommu.moduleservice.admininquiry;
+
+public class AdminInquiryCommentServiceImpl {
+
+}

--- a/module-service/src/main/java/com/welcommu/moduleservice/admininquiry/AdminInquiryService.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/admininquiry/AdminInquiryService.java
@@ -1,93 +1,26 @@
 package com.welcommu.moduleservice.admininquiry;
 
-import com.welcommu.modulecommon.exception.CustomErrorCode;
 import com.welcommu.modulecommon.exception.CustomException;
-import com.welcommu.moduledomain.admininquiry.AdminInquiry;
-import com.welcommu.moduledomain.admininquiry.AdminInquiryStatus;
-import com.welcommu.moduledomain.admininquiry.AdminInquiryType;
-import com.welcommu.moduledomain.project.Project;
 import com.welcommu.moduledomain.user.User;
-import com.welcommu.moduleinfra.admininquiry.AdminInquiryRepository;
-import com.welcommu.moduleinfra.project.ProjectRepository;
 import com.welcommu.moduleservice.admininquiry.dto.AdminInquiryDetailResponse;
 import com.welcommu.moduleservice.admininquiry.dto.AdminInquiryListResponse;
 import com.welcommu.moduleservice.admininquiry.dto.AdminInquiryRequest;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
-public class AdminInquiryService {
+public interface AdminInquiryService {
 
-    private final AdminInquiryRepository adminInquiryRepository;
-    private final ProjectRepository projectRepository;
+    void createAdminInquiry(User user, AdminInquiryRequest request) throws CustomException;
 
-    public void createAdminInquiry(User user, AdminInquiryRequest adminInquiryRequest) {
+    void modifyAdminInquiry(Long inquiryId, User user, AdminInquiryRequest request)
+        throws CustomException;
 
-        Project project = null;
+    List<AdminInquiryListResponse> getAdminInquiryList();
 
-        if (adminInquiryRequest.getInquiryType() == AdminInquiryType.PROJECT) {
-            project = projectRepository.findById(adminInquiryRequest.getProjectId())
-                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_PROJECT));
-        }
+    AdminInquiryDetailResponse getAdminInquiryDetail(Long inquiryId) throws CustomException;
 
-        AdminInquiry newInquiry = adminInquiryRequest.toEntity(user, adminInquiryRequest, project);
-        adminInquiryRepository.save(newInquiry);
-    }
+    List<AdminInquiryListResponse> getAdminInquiriesByUser(User user);
 
-    @Transactional
-    public void modifyAdminInquiry(Long admininquiryId, User user,
-        AdminInquiryRequest adminInquiryRequest) {
-        AdminInquiry existingInquiry = adminInquiryRepository.findById(admininquiryId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY));
+    void completeAdminInquiry(Long inquiryId) throws CustomException;
 
-        if (adminInquiryRequest.getInquiryType() == AdminInquiryType.PROJECT) {
-            Project changedProject = projectRepository.findById(adminInquiryRequest.getProjectId())
-                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_PROJECT));
-            existingInquiry.setProject(changedProject);
-        }
-
-        existingInquiry.setInquiryType(adminInquiryRequest.getInquiryType());
-        existingInquiry.setTitle(adminInquiryRequest.getTitle());
-        existingInquiry.setContent(adminInquiryRequest.getContent());
-    }
-
-    public List<AdminInquiryListResponse> getAdminInquiryList() {
-        List<AdminInquiry> adminInquiryList = adminInquiryRepository.findAllByDeletedAtIsNull();
-        return adminInquiryList.stream()
-            .map(AdminInquiryListResponse::from)
-            .collect(Collectors.toList());
-    }
-
-    public AdminInquiryDetailResponse getAdminInquiryDetail(Long admininquiryId) {
-        AdminInquiry existingInquiry = adminInquiryRepository.findById(admininquiryId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY));
-        return AdminInquiryDetailResponse.from(existingInquiry);
-    }
-
-    public List<AdminInquiryListResponse> getAdminInquiriesByUser(User user) {
-        List<AdminInquiry> userInquiries = adminInquiryRepository.findByCreatorAndDeletedAtIsNull(
-            user);
-        return userInquiries.stream()
-            .map(AdminInquiryListResponse::from)
-            .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public void completeAdminInquiry(Long admininquiryId) {
-        AdminInquiry existingInquiry = adminInquiryRepository.findById(admininquiryId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY));
-        existingInquiry.setInquiryStatus(AdminInquiryStatus.COMPLETED);
-    }
-
-    @Transactional
-    public void deleteAdminInquiry(Long admininquiryId) {
-        AdminInquiry existingInquiry = adminInquiryRepository.findById(admininquiryId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY));
-        existingInquiry.setDeletedAt(LocalDateTime.now());
-    }
+    void deleteAdminInquiry(Long inquiryId) throws CustomException;
 }

--- a/module-service/src/main/java/com/welcommu/moduleservice/admininquiry/AdminInquiryServiceImpl.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/admininquiry/AdminInquiryServiceImpl.java
@@ -1,0 +1,94 @@
+package com.welcommu.moduleservice.admininquiry;
+
+import com.welcommu.modulecommon.exception.CustomErrorCode;
+import com.welcommu.modulecommon.exception.CustomException;
+import com.welcommu.moduledomain.admininquiry.AdminInquiry;
+import com.welcommu.moduledomain.admininquiry.AdminInquiryStatus;
+import com.welcommu.moduledomain.admininquiry.AdminInquiryType;
+import com.welcommu.moduledomain.project.Project;
+import com.welcommu.moduledomain.user.User;
+import com.welcommu.moduleinfra.admininquiry.AdminInquiryRepository;
+import com.welcommu.moduleinfra.project.ProjectRepository;
+import com.welcommu.moduleservice.admininquiry.dto.AdminInquiryDetailResponse;
+import com.welcommu.moduleservice.admininquiry.dto.AdminInquiryListResponse;
+import com.welcommu.moduleservice.admininquiry.dto.AdminInquiryRequest;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminInquiryServiceImpl implements AdminInquiryService {
+
+    private final AdminInquiryRepository adminInquiryRepository;
+    private final ProjectRepository projectRepository;
+
+    @Override
+    public void createAdminInquiry(User user, AdminInquiryRequest request) {
+        Project project = null;
+        if (request.getInquiryType() == AdminInquiryType.PROJECT) {
+            project = projectRepository.findById(request.getProjectId())
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_PROJECT));
+        }
+        AdminInquiry newInquiry = request.toEntity(user, request, project);
+        adminInquiryRepository.save(newInquiry);
+    }
+
+    @Override
+    @Transactional
+    public void modifyAdminInquiry(Long inquiryId, User user, AdminInquiryRequest request) {
+        AdminInquiry inquiry = adminInquiryRepository.findById(inquiryId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY));
+
+        if (request.getInquiryType() == AdminInquiryType.PROJECT) {
+            Project project = projectRepository.findById(request.getProjectId())
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_PROJECT));
+            inquiry.setProject(project);
+        }
+        inquiry.setInquiryType(request.getInquiryType());
+        inquiry.setTitle(request.getTitle());
+        inquiry.setContent(request.getContent());
+    }
+
+    @Override
+    public List<AdminInquiryListResponse> getAdminInquiryList() {
+        return adminInquiryRepository.findAllByDeletedAtIsNull()
+            .stream()
+            .map(AdminInquiryListResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public AdminInquiryDetailResponse getAdminInquiryDetail(Long inquiryId) {
+        AdminInquiry inquiry = adminInquiryRepository.findById(inquiryId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY));
+        return AdminInquiryDetailResponse.from(inquiry);
+    }
+
+    @Override
+    public List<AdminInquiryListResponse> getAdminInquiriesByUser(User user) {
+        return adminInquiryRepository.findByCreatorAndDeletedAtIsNull(user)
+            .stream()
+            .map(AdminInquiryListResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void completeAdminInquiry(Long inquiryId) {
+        AdminInquiry inquiry = adminInquiryRepository.findById(inquiryId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY));
+        inquiry.setInquiryStatus(AdminInquiryStatus.COMPLETED);
+    }
+
+    @Override
+    @Transactional
+    public void deleteAdminInquiry(Long inquiryId) {
+        AdminInquiry inquiry = adminInquiryRepository.findById(inquiryId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY));
+        inquiry.setDeletedAt(LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목 형식은 "[type] 제목"으로 통일합니다. -->
<!-- 사용하지 않는 항목은 지워주세요.-->

>어떻게 써야 할지 고민될 땐 [Wiki Link](https://github.com/Kernel360/KDEV4-VIVIM-BE/wiki/PR-EXAMPLE-:-%ED%92%80-%EB%A6%AC%ED%80%98%EC%8A%A4%ED%8A%B8-%EC%96%B4%EB%96%BB%EA%B2%8C-%EC%93%B0%EB%A9%B4-%EC%A2%8B%EC%9D%84%EA%B9%8C%3F)를 참고해주세요.

---

## 관련 이슈
<!-- 기입 예 : #3 -->
#120 
<br>

---

## 🔧 변경 사항

### ✨ 요약
기존 `AdminInquiryController`, `AdminInquiryCommentController`가 서비스 구현체인 `AdminInquiryServiceImpl`, `AdminInquiryCommentServiceImpl`에 직접 의존하고 있어,  
DIP(Dependency Inversion Principle, 의존성 역전 원칙)을 위배하는 구조였습니다.

이에 따라 비즈니스 로직을 추상화한 인터페이스를 도입하고, Controller가 구현체가 아닌 인터페이스에 의존하도록 리팩토링하였습니다.

---

### 🧠 설계 의도

- DIP 원칙 실현
  : 상위 계층(Controller)은 하위 구현체가 아닌 추상화(인터페이스)에 의존해야 하며,  
  변경에 대한 유연성을 확보할 수 있도록 구조를 개선하였습니다.

- 테스트 및 확장성 향상
  : 인터페이스 기반으로 구조를 변경함으로써  
  테스트 시 Mock 객체 주입이 가능해지고,  
  구현체 교체도 용이해졌습니다.

---

## 확인 사항

- [x] 포스트맨/스웨거 확인 여부
- [ ] 테스트 코드 작성 여부
- [x] 프론트엔드 연동 여부
- [x] 배포 여부

<br>

---