### PR TITLE
[refactor] #120 NotificationService 인터페이스 분리

### DIFF
--- a/module-api/src/main/java/com/welcommu/moduleapi/notification/NotificationController.java
+++ b/module-api/src/main/java/com/welcommu/moduleapi/notification/NotificationController.java
@@ -5,6 +5,7 @@ import com.welcommu.moduledomain.auth.AuthUserDetailsImpl;
 import com.welcommu.moduleservice.notification.NotificationService;
 import com.welcommu.moduleservice.notification.dto.NotificationRequest;
 import com.welcommu.moduleservice.notification.dto.NotificationResponse;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,8 +38,7 @@ public class NotificationController {
 
     @GetMapping("/subscribe")
     public ResponseEntity<SseEmitter> subscribe(
-        @AuthenticationPrincipal AuthUserDetailsImpl userDetails) {
-        log.info("SSE 구독 신청 - userId: {}", userDetails.getUser().getId());
+        @AuthenticationPrincipal AuthUserDetailsImpl userDetails) throws IOException {
         SseEmitter emitter = notificationService.subscribe(userDetails.getUser().getId());
         return ResponseEntity.ok().body(emitter);
     }

--- a/module-api/src/main/java/com/welcommu/moduleapi/notification/NotificationController.java
+++ b/module-api/src/main/java/com/welcommu/moduleapi/notification/NotificationController.java
@@ -5,6 +5,8 @@ import com.welcommu.moduledomain.auth.AuthUserDetailsImpl;
 import com.welcommu.moduleservice.notification.NotificationService;
 import com.welcommu.moduleservice.notification.dto.NotificationRequest;
 import com.welcommu.moduleservice.notification.dto.NotificationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,11 +27,13 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "알림 API", description = "알림을 생성, 전송, 조회, 읽음, 삭제시킬 수 있으며 SSE연결을 통한 실시간 알림도 가능합니다.")
 public class NotificationController {
 
     private final NotificationService notificationService;
 
     @PostMapping
+    @Operation(summary = "알림을 전송합니다.")
     public ResponseEntity<ApiResponse> sendNotification(@RequestBody NotificationRequest request) {
         notificationService.sendNotification(request);
         return ResponseEntity.ok()
@@ -37,6 +41,7 @@ public class NotificationController {
     }
 
     @GetMapping("/subscribe")
+    @Operation(summary = "SSE에 연결합니다.")
     public ResponseEntity<SseEmitter> subscribe(
         @AuthenticationPrincipal AuthUserDetailsImpl userDetails) throws IOException {
         SseEmitter emitter = notificationService.subscribe(userDetails.getUser().getId());
@@ -44,6 +49,7 @@ public class NotificationController {
     }
 
     @GetMapping
+    @Operation(summary = "알림을 조회 합니다.")
     public ResponseEntity<List<NotificationResponse>> getNotifications(
         @AuthenticationPrincipal AuthUserDetailsImpl userDetails
     ) {
@@ -52,12 +58,14 @@ public class NotificationController {
     }
 
     @PatchMapping("/{notificationId}/read")
+    @Operation(summary = "알림을 읽음 처리 합니다.")
     public ResponseEntity<ApiResponse> markAsRead(@PathVariable Long notificationId) {
         notificationService.markAsRead(notificationId);
         return ResponseEntity.ok().body(new ApiResponse(HttpStatus.OK.value(), "알림을 읽었습니다."));
     }
 
     @PatchMapping("/read-all")
+    @Operation(summary = "알림을 모두 읽습니다.")
     public ResponseEntity<Void> markAllNotificationsAsRead(
         @AuthenticationPrincipal AuthUserDetailsImpl userDetails) {
         notificationService.markAllAsRead(userDetails.getUser().getId());
@@ -65,6 +73,7 @@ public class NotificationController {
     }
 
     @PatchMapping("/{notificationId}")
+    @Operation(summary = "알림을 삭제합니다.")
     public ResponseEntity<ApiResponse> deleteNotification(@PathVariable Long notificationId) {
         notificationService.deleteNotification(notificationId);
         return ResponseEntity.ok().body(new ApiResponse(HttpStatus.OK.value(), "알림이 삭제되었습니다."));

--- a/module-service/src/main/java/com/welcommu/moduleservice/notification/NotificationService.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/notification/NotificationService.java
@@ -1,90 +1,22 @@
 package com.welcommu.moduleservice.notification;
 
-import com.welcommu.moduledomain.notification.Notification;
-import com.welcommu.moduleinfra.notification.NotificationRepository;
 import com.welcommu.moduleservice.notification.dto.NotificationRequest;
 import com.welcommu.moduleservice.notification.dto.NotificationResponse;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-@Service
-@Slf4j
-@RequiredArgsConstructor
-public class NotificationService {
+public interface NotificationService {
 
-    private final NotificationRepository notificationRepository;
+    SseEmitter subscribe(Long userId) throws IOException;
 
-    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    List<NotificationResponse> getNotifications(Long userId);
 
-    public SseEmitter subscribe(Long userId) {
-        SseEmitter emitter = new SseEmitter(1000L * 60L * 60L);//1시간
-        emitters.put(userId, emitter);
+    void markAsRead(Long notificationId);
 
-        emitter.onCompletion(() -> emitters.remove(userId));
-        emitter.onTimeout(() -> emitters.remove(userId));
+    void markAllAsRead(Long userId);
 
-        try {
-            emitter.send(SseEmitter.event().name("connect").data("connected"));
-        } catch (IOException e) {
-            emitter.completeWithError(e);
-        }
+    void sendNotification(NotificationRequest request);
 
-        return emitter;
-    }
-
-    public List<NotificationResponse> getNotifications(Long userId) {
-        List<Notification> notifications = notificationRepository.findByReceiverIdOrderByCreatedAtDesc(
-            userId);
-        return notifications.stream()
-            .map(NotificationResponse::from)
-            .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public void markAsRead(Long notificationId) {
-        Notification notification = notificationRepository.findById(notificationId)
-            .orElseThrow(() -> new NoSuchElementException("Notification not found"));
-        notification.markAsRead();
-    }
-
-    @Transactional
-    public void markAllAsRead(Long userId) {
-        notificationRepository.markAllAsReadByUserId(userId);
-    }
-
-    @Transactional
-    public void sendNotification(NotificationRequest request) {
-        Notification notification = request.toEntity(request);
-        Notification savedNotification = notificationRepository.save(notification);
-        NotificationResponse notificationResponse = NotificationResponse.from(savedNotification);
-
-        //SSE 구독중인 경우만 즉시 Push
-        SseEmitter emitter = emitters.get(request.getReceiverId());
-        if (emitter != null) {
-            try {
-                emitter.send(SseEmitter.event()
-                    .name("notification")
-                    .data(notificationResponse));
-            } catch (IOException | IllegalStateException e) {
-                emitter.completeWithError(e); // optional
-                emitters.remove(request.getReceiverId());
-            }
-        }
-    }
-
-    @Transactional
-    public void deleteNotification(Long notificationId) {
-        Notification notification = notificationRepository.findById(notificationId)
-            .orElseThrow(() -> new NoSuchElementException("Notification not found"));
-        notification.setDeletedAt();
-    }
+    void deleteNotification(Long notificationId);
 }

--- a/module-service/src/main/java/com/welcommu/moduleservice/notification/NotificationServiceImpl.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/notification/NotificationServiceImpl.java
@@ -1,0 +1,85 @@
+package com.welcommu.moduleservice.notification;
+
+import com.welcommu.moduledomain.notification.Notification;
+import com.welcommu.moduleinfra.notification.NotificationRepository;
+import com.welcommu.moduleservice.notification.dto.NotificationRequest;
+import com.welcommu.moduleservice.notification.dto.NotificationResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    @Override
+    public SseEmitter subscribe(Long userId) throws IOException {
+        SseEmitter emitter = new SseEmitter(1000L * 60L * 60L); // 1시간
+        emitters.put(userId, emitter);
+        emitter.onCompletion(() -> emitters.remove(userId));
+        emitter.onTimeout(() -> emitters.remove(userId));
+        emitter.send(SseEmitter.event().name("connect").data("connected"));
+        return emitter;
+    }
+
+    @Override
+    public List<NotificationResponse> getNotifications(Long userId) {
+        return notificationRepository
+            .findByReceiverIdOrderByCreatedAtDesc(userId)
+            .stream()
+            .map(NotificationResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void markAsRead(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+            .orElseThrow(() -> new NoSuchElementException("Notification not found"));
+        notification.markAsRead();
+    }
+
+    @Override
+    @Transactional
+    public void markAllAsRead(Long userId) {
+        notificationRepository.markAllAsReadByUserId(userId);
+    }
+
+    @Override
+    @Transactional
+    public void sendNotification(NotificationRequest request) {
+        Notification notification = request.toEntity(request);
+        Notification saved = notificationRepository.save(notification);
+        NotificationResponse response = NotificationResponse.from(saved);
+
+        SseEmitter emitter = emitters.get(request.getReceiverId());
+        if (emitter != null) {
+            try {
+                emitter.send(SseEmitter.event().name("notification").data(response));
+            } catch (IOException | IllegalStateException e) {
+                emitter.completeWithError(e);
+                emitters.remove(request.getReceiverId());
+            }
+        }
+    }
+
+    @Override
+    @Transactional
+    public void deleteNotification(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+            .orElseThrow(() -> new NoSuchElementException("Notification not found"));
+        notification.setDeletedAt();
+    }
+}


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목 형식은 "[type] 제목"으로 통일합니다. -->
<!-- 사용하지 않는 항목은 지워주세요.-->

>어떻게 써야 할지 고민될 땐 [Wiki Link](https://github.com/Kernel360/KDEV4-VIVIM-BE/wiki/PR-EXAMPLE-:-%ED%92%80-%EB%A6%AC%ED%80%98%EC%8A%A4%ED%8A%B8-%EC%96%B4%EB%96%BB%EA%B2%8C-%EC%93%B0%EB%A9%B4-%EC%A2%8B%EC%9D%84%EA%B9%8C%3F)를 참고해주세요.

---

## 관련 이슈
<!-- 기입 예 : #3 -->
#120 
<br>

---

## 🔧 변경 사항

### ✨ 요약
기존 `NotificationController`가 서비스 구현체인`NotificationServiceImpl`에 직접 의존하고 있어,  
DIP(Dependency Inversion Principle, 의존성 역전 원칙)을 위배하는 구조였습니다.

이에 따라 비즈니스 로직을 추상화한 인터페이스를 도입하고, Controller가 구현체가 아닌 인터페이스에 의존하도록 리팩토링하였습니다.

스웨거 어노테이션도 추가 했습니다.

---

### 🧠 설계 의도

- DIP 원칙 실현
  : 상위 계층(Controller)은 하위 구현체가 아닌 추상화(인터페이스)에 의존해야 하며,  
  변경에 대한 유연성을 확보할 수 있도록 구조를 개선하였습니다.

- 테스트 및 확장성 향상
  : 인터페이스 기반으로 구조를 변경함으로써  
  테스트 시 Mock 객체 주입이 가능해지고,  
  구현체 교체도 용이해졌습니다.

---

## 확인 사항

- [x] 포스트맨/스웨거 확인 여부
- [ ] 테스트 코드 작성 여부
- [x] 프론트엔드 연동 여부
- [x] 배포 여부

<br>

---