### PR TITLE
[feature] #120 AdminInquiryCommentService 인터페이스 분리

### DIFF
--- a/module-service/src/main/java/com/welcommu/moduleservice/admininquiry/AdminInquiryCommentServiceImpl.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/admininquiry/AdminInquiryCommentServiceImpl.java
@@ -1,5 +1,59 @@
 package com.welcommu.moduleservice.admininquiry;
 
-public class AdminInquiryCommentServiceImpl {
+import com.welcommu.modulecommon.exception.CustomErrorCode;
+import com.welcommu.modulecommon.exception.CustomException;
+import com.welcommu.moduledomain.admininquiry.AdminInquiry;
+import com.welcommu.moduledomain.admininquiry.AdminInquiryComment;
+import com.welcommu.moduledomain.user.User;
+import com.welcommu.moduleinfra.admininquiry.AdminInquiryCommentRepository;
+import com.welcommu.moduleinfra.admininquiry.AdminInquiryRepository;
+import com.welcommu.moduleservice.admininquiry.dto.AdminInquiryCommentListResponse;
+import com.welcommu.moduleservice.admininquiry.dto.AdminInquiryCommentRequest;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Service
+@RequiredArgsConstructor
+public class AdminInquiryCommentServiceImpl implements AdminInquiryCommentService {
+
+    private final AdminInquiryCommentRepository adminInquiryCommentRepository;
+    private final AdminInquiryRepository adminInquiryRepository;
+
+    @Override
+    public void createAdminInquiryComment(User user, AdminInquiryCommentRequest request,
+        Long inquiryId) {
+        AdminInquiry inquiry = adminInquiryRepository.findById(inquiryId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY));
+        AdminInquiryComment comment = request.toEntity(user, request, inquiry);
+        adminInquiryCommentRepository.save(comment);
+    }
+
+    @Override
+    @Transactional
+    public void modifyAdminInquiryComment(Long commentId, AdminInquiryCommentRequest request) {
+        AdminInquiryComment existing = adminInquiryCommentRepository.findById(commentId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY_COMMENT));
+        existing.setContent(request.getContent());
+    }
+
+    @Override
+    public List<AdminInquiryCommentListResponse> getAdminInquiryCommentList(Long inquiryId) {
+        return adminInquiryCommentRepository
+            .findAllByAdminInquiryIdAndDeletedAtIsNull(inquiryId)
+            .stream()
+            .map(AdminInquiryCommentListResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void deleteAdminInquiryComment(Long commentId) {
+        AdminInquiryComment existing = adminInquiryCommentRepository.findById(commentId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_INQUIRY_COMMENT));
+        existing.setDeletedAt(LocalDateTime.now());
+    }
 }


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목 형식은 "[type] 제목"으로 통일합니다. -->
<!-- 사용하지 않는 항목은 지워주세요.-->

>어떻게 써야 할지 고민될 땐 [Wiki Link](https://github.com/Kernel360/KDEV4-VIVIM-BE/wiki/PR-EXAMPLE-:-%ED%92%80-%EB%A6%AC%ED%80%98%EC%8A%A4%ED%8A%B8-%EC%96%B4%EB%96%BB%EA%B2%8C-%EC%93%B0%EB%A9%B4-%EC%A2%8B%EC%9D%84%EA%B9%8C%3F)를 참고해주세요.

---

## 관련 이슈
<!-- 기입 예 : #3 -->
#120 
<br>

---

## 🔧 변경 사항

구현이 안되어있던  `AdminInquiryCommentServiceImpl`를 구현했습니다.

---

## 확인 사항

- [x] 포스트맨/스웨거 확인 여부
- [ ] 테스트 코드 작성 여부
- [x] 프론트엔드 연동 여부
- [x] 배포 여부

<br>

---