### PR TITLE
[refactor] file, link 인터페이스 분리

### DIFF
--- a/module-api/src/main/java/com/welcommu/moduleapi/file/FileController.java
+++ b/module-api/src/main/java/com/welcommu/moduleapi/file/FileController.java
@@ -197,7 +197,6 @@ public class FileController {
         GeneratePresignedUrlRequest req = new GeneratePresignedUrlRequest(bucketName, objectKey)
             .withMethod(HttpMethod.GET)
             .withExpiration(new Date(System.currentTimeMillis() + URL_EXPIRATION_MS));
-        org.springframework.web.servlet.mvc.method.annotation.SseEmitter event; // remove unused import
         com.amazonaws.services.s3.model.ResponseHeaderOverrides headers = new com.amazonaws.services.s3.model.ResponseHeaderOverrides();
         String encodedName = UriUtils.encode(file.getFileName(), StandardCharsets.UTF_8);
         headers.setContentDisposition("attachment; filename=\"" + encodedName + "\"");

--- a/module-service/src/main/java/com/welcommu/moduleservice/file/FileService.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/file/FileService.java
@@ -1,90 +1,25 @@
 package com.welcommu.moduleservice.file;
 
-
-import com.welcommu.modulecommon.exception.CustomErrorCode;
 import com.welcommu.modulecommon.exception.CustomException;
 import com.welcommu.moduledomain.file.File;
 import com.welcommu.moduledomain.file.ReferenceType;
-import com.welcommu.moduleinfra.file.FileRepository;
 import com.welcommu.moduleservice.file.dto.FileListResponse;
 import com.welcommu.moduleservice.file.dto.FileRequest;
 import com.welcommu.moduleservice.file.dto.MultipartFileMetadataRequest;
 import java.util.List;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+public interface FileService {
 
-@Service
-@RequiredArgsConstructor
-public class FileService {
+    void createMultipartFile(MultipartFileMetadataRequest request, ReferenceType referenceType,
+        Long referenceId, String fileUrl);
 
-    private final FileRepository fileRepository;
+    void createFile(FileRequest request, ReferenceType referenceType, Long referenceId)
+        throws CustomException;
 
+    List<FileListResponse> getFilesByReference(ReferenceType referenceType, Long referenceId);
 
-    public void createMultipartPostFile(MultipartFileMetadataRequest request,
-        Long postId, String fileUrl) {
-        File newFile = request.toEntity(request, ReferenceType.POST, postId, fileUrl);
-        fileRepository.save(newFile);
+    File getFileInfo(Long fileId) throws CustomException;
 
-    }
-
-    public void createMultipartApprovalFile(MultipartFileMetadataRequest request,
-        Long postId, String fileUrl) {
-        File newFile = request.toEntity(request, ReferenceType.APPROVAL, postId, fileUrl);
-        fileRepository.save(newFile);
-
-    }
-
-    public void createMultipartDecisionFile(MultipartFileMetadataRequest request,
-        Long postId, String fileUrl) {
-        File newFile = request.toEntity(request, ReferenceType.DECISION, postId, fileUrl);
-        fileRepository.save(newFile);
-
-    }
-
-    public void createPostFile(FileRequest request, Long postId) {
-
-        File newFile = request.toEntity(request, ReferenceType.POST, postId);
-        fileRepository.save(newFile);
-    }
-
-
-    public List<FileListResponse> getPostFiles(Long postId) {
-        List<File> files = fileRepository.findAllByReferenceIdAndReferenceTypeAndDeletedAtIsNull(
-            postId, ReferenceType.POST);
-        return files.stream()
-            .map(FileListResponse::from)
-            .collect(Collectors.toList());
-    }
-
-    public List<FileListResponse> getApprovalFiles(Long approvalId) {
-        List<File> files = fileRepository.findAllByReferenceIdAndReferenceTypeAndDeletedAtIsNull(
-            approvalId, ReferenceType.APPROVAL);
-        return files.stream()
-            .map(FileListResponse::from)
-            .collect(Collectors.toList());
-    }
-
-    public List<FileListResponse> getDecisionFiles(Long decisionId) {
-        List<File> files = fileRepository.findAllByReferenceIdAndReferenceTypeAndDeletedAtIsNull(
-            decisionId, ReferenceType.DECISION);
-        return files.stream()
-            .map(FileListResponse::from)
-            .collect(Collectors.toList());
-    }
-
-    public File getFileInfo(Long fileId) {
-        return fileRepository.findById(fileId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_FILE));
-    }
-
-    @Transactional
-    public void deleteFile(Long fileId) {
-        File existingFile = fileRepository.findById(fileId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_FILE));
-        existingFile.setDeletedAt();
-    }
-
+    void deleteFile(Long fileId) throws CustomException;
 }
+

--- a/module-service/src/main/java/com/welcommu/moduleservice/file/FileServiceImpl.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/file/FileServiceImpl.java
@@ -1,0 +1,62 @@
+package com.welcommu.moduleservice.file;
+
+import com.welcommu.modulecommon.exception.CustomErrorCode;
+import com.welcommu.modulecommon.exception.CustomException;
+import com.welcommu.moduledomain.file.File;
+import com.welcommu.moduledomain.file.ReferenceType;
+import com.welcommu.moduleinfra.file.FileRepository;
+import com.welcommu.moduleservice.file.dto.FileListResponse;
+import com.welcommu.moduleservice.file.dto.FileRequest;
+import com.welcommu.moduleservice.file.dto.MultipartFileMetadataRequest;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FileServiceImpl implements FileService {
+
+    private final FileRepository fileRepository;
+
+    @Override
+    public void createMultipartFile(MultipartFileMetadataRequest request,
+        ReferenceType referenceType, Long referenceId, String fileUrl) {
+        File newFile = request.toEntity(request, referenceType, referenceId, fileUrl);
+        fileRepository.save(newFile);
+    }
+
+    @Override
+    public void createFile(FileRequest request, ReferenceType referenceType, Long referenceId)
+        throws CustomException {
+        File newFile = request.toEntity(request, referenceType, referenceId);
+        fileRepository.save(newFile);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<FileListResponse> getFilesByReference(ReferenceType referenceType,
+        Long referenceId) {
+        return fileRepository.findAllByReferenceIdAndReferenceTypeAndDeletedAtIsNull(
+                referenceId, referenceType)
+            .stream()
+            .map(FileListResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public File getFileInfo(Long fileId) throws CustomException {
+        return fileRepository.findById(fileId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_FILE));
+    }
+
+    @Override
+    @Transactional
+    public void deleteFile(Long fileId) throws CustomException {
+        File existingFile = fileRepository.findById(fileId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_FILE));
+        existingFile.setDeletedAt();
+    }
+}

--- a/module-service/src/main/java/com/welcommu/moduleservice/link/LinkService.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/link/LinkService.java
@@ -1,79 +1,25 @@
 package com.welcommu.moduleservice.link;
 
-
-import com.welcommu.modulecommon.exception.CustomErrorCode;
 import com.welcommu.modulecommon.exception.CustomException;
-import com.welcommu.moduledomain.file.ReferenceType;
-import com.welcommu.moduledomain.link.Link;
-import com.welcommu.moduleinfra.link.LinkRepository;
-import com.welcommu.moduleservice.link.audit.LinkAuditService;
 import com.welcommu.moduleservice.link.dto.LinkListResponse;
 import com.welcommu.moduleservice.link.dto.LinkRequest;
-import com.welcommu.moduleservice.user.dto.UserSnapshot;
 import java.util.List;
-import java.util.function.LongConsumer;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class LinkService {
+public interface LinkService {
 
-    private final LinkRepository linkRepository;
-    private final LinkAuditService linkAuditService;
+    void createPostLink(Long postId, LinkRequest request, Long creatorId) throws CustomException;
 
-    public void createPostLink(Long postId, LinkRequest request, Long creatorId) {
-        Link newLink = request.toEntity(request, ReferenceType.POST, postId);
-        Link savedLink =  linkRepository.save(newLink);
-        linkAuditService.createAuditLog(LinkListResponse.from(savedLink), creatorId);
-    }
+    void createApprovalLink(Long approvalId, LinkRequest request, Long creatorId)
+        throws CustomException;
 
-    public void createApprovalLink(Long approvalId, LinkRequest request, Long creatorId) {
+    void createDecisionLink(Long decisionId, LinkRequest request, Long creatorId)
+        throws CustomException;
 
-        Link newLink = request.toEntity(request, ReferenceType.APPROVAL, approvalId);
-        Link savedLink =  linkRepository.save(newLink);
-        linkAuditService.createAuditLog(LinkListResponse.from(savedLink), creatorId);
-    }
+    List<LinkListResponse> getPostLinks(Long postId);
 
-    public void createDecisionLink(Long decisionId, LinkRequest request, Long creatorId) {
-        Link newLink = request.toEntity(request, ReferenceType.DECISION, decisionId);
-        Link savedLink =  linkRepository.save(newLink);
-        linkAuditService.createAuditLog(LinkListResponse.from(savedLink), creatorId);
-    }
+    List<LinkListResponse> getApprovalLinks(Long approvalId);
 
-    public List<LinkListResponse> getPostLinks(Long postId) {
-        List<Link> links = linkRepository.findAllByReferenceIdAndReferenceTypeAndDeletedAtIsNull(
-            postId, ReferenceType.POST);
-        return links.stream()
-            .map(LinkListResponse::from)
-            .collect(Collectors.toList());
-    }
+    List<LinkListResponse> getDecisionLinks(Long decisionId);
 
-    public List<LinkListResponse> getApprovalLinks(Long approvalId) {
-        List<Link> links = linkRepository.findAllByReferenceIdAndReferenceTypeAndDeletedAtIsNull(
-            approvalId, ReferenceType.APPROVAL);
-        return links.stream()
-            .map(LinkListResponse::from)
-            .collect(Collectors.toList());
-    }
-
-    public List<LinkListResponse> getDecisionLinks(Long decisionId) {
-        List<Link> links = linkRepository.findAllByReferenceIdAndReferenceTypeAndDeletedAtIsNull(
-            decisionId, ReferenceType.DECISION);
-        return links.stream()
-            .map(LinkListResponse::from)
-            .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public void deleteLink(Long linkId, Long deleterId) {
-        Link existingLink = linkRepository.findById(linkId)
-            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_LINK));
-        existingLink.setDeletedAt();
-        linkAuditService.deleteAuditLog(LinkListResponse.from(existingLink), deleterId);
-    }
+    void deleteLink(Long linkId, Long deleterId) throws CustomException;
 }

--- a/module-service/src/main/java/com/welcommu/moduleservice/link/LinkServiceImpl.java
+++ b/module-service/src/main/java/com/welcommu/moduleservice/link/LinkServiceImpl.java
@@ -1,0 +1,91 @@
+package com.welcommu.moduleservice.link;
+
+import com.welcommu.modulecommon.exception.CustomErrorCode;
+import com.welcommu.modulecommon.exception.CustomException;
+import com.welcommu.moduledomain.file.ReferenceType;
+import com.welcommu.moduledomain.link.Link;
+import com.welcommu.moduleinfra.link.LinkRepository;
+import com.welcommu.moduleservice.link.audit.LinkAuditService;
+import com.welcommu.moduleservice.link.dto.LinkListResponse;
+import com.welcommu.moduleservice.link.dto.LinkRequest;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LinkServiceImpl implements LinkService {
+
+    private final LinkRepository linkRepository;
+    private final LinkAuditService linkAuditService;
+
+    @Override
+    @Transactional
+    public void createPostLink(Long postId, LinkRequest request, Long creatorId)
+        throws CustomException {
+        Link newLink = request.toEntity(request, ReferenceType.POST, postId);
+        Link saved = linkRepository.save(newLink);
+        linkAuditService.createAuditLog(LinkListResponse.from(saved), creatorId);
+    }
+
+    @Override
+    @Transactional
+    public void createApprovalLink(Long approvalId, LinkRequest request, Long creatorId)
+        throws CustomException {
+        Link newLink = request.toEntity(request, ReferenceType.APPROVAL, approvalId);
+        Link saved = linkRepository.save(newLink);
+        linkAuditService.createAuditLog(LinkListResponse.from(saved), creatorId);
+    }
+
+    @Override
+    @Transactional
+    public void createDecisionLink(Long decisionId, LinkRequest request, Long creatorId)
+        throws CustomException {
+        Link newLink = request.toEntity(request, ReferenceType.DECISION, decisionId);
+        Link saved = linkRepository.save(newLink);
+        linkAuditService.createAuditLog(LinkListResponse.from(saved), creatorId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LinkListResponse> getPostLinks(Long postId) {
+        return linkRepository.findAllByReferenceIdAndReferenceTypeAndDeletedAtIsNull(postId,
+                ReferenceType.POST)
+            .stream()
+            .map(LinkListResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LinkListResponse> getApprovalLinks(Long approvalId) {
+        return linkRepository.findAllByReferenceIdAndReferenceTypeAndDeletedAtIsNull(approvalId,
+                ReferenceType.APPROVAL)
+            .stream()
+            .map(LinkListResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LinkListResponse> getDecisionLinks(Long decisionId) {
+        return linkRepository.findAllByReferenceIdAndReferenceTypeAndDeletedAtIsNull(decisionId,
+                ReferenceType.DECISION)
+            .stream()
+            .map(LinkListResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void deleteLink(Long linkId, Long deleterId) throws CustomException {
+        Link existing = linkRepository.findById(linkId)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_LINK));
+        existing.setDeletedAt();
+        linkAuditService.deleteAuditLog(LinkListResponse.from(existing), deleterId);
+    }
+}


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목 형식은 "[type] 제목"으로 통일합니다. -->
<!-- 사용하지 않는 항목은 지워주세요.-->

>어떻게 써야 할지 고민될 땐 [Wiki Link](https://github.com/Kernel360/KDEV4-VIVIM-BE/wiki/PR-EXAMPLE-:-%ED%92%80-%EB%A6%AC%ED%80%98%EC%8A%A4%ED%8A%B8-%EC%96%B4%EB%96%BB%EA%B2%8C-%EC%93%B0%EB%A9%B4-%EC%A2%8B%EC%9D%84%EA%B9%8C%3F)를 참고해주세요.

---

## 관련 이슈
<!-- 기입 예 : #3 -->
#120 
<br>

---

## 🔧 변경 사항

### ✨ 요약
기존 `FileController`, `LinkController`가 서비스 구현체인 `FileServiceImpl`, `LinkServiceImpl`에 직접 의존하고 있어,  
DIP(Dependency Inversion Principle, 의존성 역전 원칙)을 위배하는 구조였습니다.

이에 따라 비즈니스 로직을 추상화한 인터페이스를 도입하고, Controller가 구현체가 아닌 인터페이스에 의존하도록 리팩토링하였습니다.

---

### 🧠 설계 의도

- DIP 원칙 실현
  : 상위 계층(Controller)은 하위 구현체가 아닌 추상화(인터페이스)에 의존해야 하며,  
  변경에 대한 유연성을 확보할 수 있도록 구조를 개선하였습니다.

- 테스트 및 확장성 향상
  : 인터페이스 기반으로 구조를 변경함으로써  
  테스트 시 Mock 객체 주입이 가능해지고,  
  구현체 교체도 용이해졌습니다.

---

## 확인 사항

- [x] 포스트맨/스웨거 확인 여부
- [ ] 테스트 코드 작성 여부
- [x] 프론트엔드 연동 여부
- [x] 배포 여부

<br>

---