### PR TITLE
[feature] #177 Redis 장애 시 503 반환을 위한 ExceptionHandler 추가

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     implementation 'com.amazonaws:aws-java-sdk-core'
     implementation 'com.amazonaws:aws-java-sdk-sts'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation project(':module-common')
     implementation project(':module-domain')
     implementation project(':module-infra')

--- a/module-api/src/main/java/com/welcommu/moduleapi/exception/GlobalExceptionHandler.java
+++ b/module-api/src/main/java/com/welcommu/moduleapi/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.welcommu.moduleapi.exception;
+
+import com.welcommu.modulecommon.dto.ApiResponse;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RedisConnectionFailureException.class)
+    public ResponseEntity<ApiResponse> handleRedisConnectionFailure(
+        RedisConnectionFailureException ex) {
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+            .body(new ApiResponse(503, "Redis 서버가 꺼져있어 요청을 처리할 수 없습니다."));
+    }
+}


### PR DESCRIPTION

## 변경 사항

* Redis docker 미실행 또는 연결 불가 시 발생하는 `RedisConnectionFailureException`을 별도로 핸들링하도록 `GlobalExceptionHandler` 개선
* 해당 예외 발생 시 503 (Service Unavailable) 상태 코드와 함께 `REDIS_CONNECTION_FAILED` 코드 및 안내 메시지 반환
* 프론트엔드에서 Redis 장애 여부를 명확히 식별할 수 있도록 통일된 응답 포맷 적용
* 기존 Redis 장애 시 불명확하게 500으로 반환되던 문제 개선

<br>

---

## 확인 사항

* [ ] 포스트맨/스웨거 확인
* [ ] 테스트 코드 작성 (추가 필요 여부 검토 중)
* [x] 프론트엔드 연동 확인

<br>

---

## 트러블 슈팅

### 배경

Redis docker image가 실행되지 않았을 때 API 호출 시 Redis 연결 오류로 인해 서비스 전체가 500 Internal Server Error로 반환되는 문제 발생

### 이슈

```java
org.springframework.data.redis.RedisConnectionFailureException: Unable to connect to Redis
Caused by: java.net.ConnectException: Connection refused
```

### 원인 분석

* Redis 연결 실패 시 Spring 기본 동작으로 500 에러가 발생
* 프론트엔드에서 장애 원인 식별 불가 → 사용자 경험 및 장애 대응 지연

### 수정 코드 또는 해결 방법

```java
@ExceptionHandler(RedisConnectionFailureException.class)
public ResponseEntity<ApiResponse<Void>> handleRedisConnectionFailure(RedisConnectionFailureException ex) {
    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
            .body(ApiResponse.error("REDIS_CONNECTION_FAILED", "Redis 서버가 꺼져있어 요청을 처리할 수 없습니다."));
}
```

